### PR TITLE
Change apiVersion to apps/v1

### DIFF
--- a/charts/emqx/templates/StatefulSet.yaml
+++ b/charts/emqx/templates/StatefulSet.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "emqx.fullname" . }}


### PR DESCRIPTION
Helm install chart failed with error: `helm no matches for kind "StatefulSet" in version "apps/v1beta1"`
with helm v2.14.3 & kubernetes v1.16.0